### PR TITLE
Add pymod.nimble file

### DIFF
--- a/pymod.nimble
+++ b/pymod.nimble
@@ -1,0 +1,9 @@
+[Package]
+name          = "pymod"
+version       = "0.1.0"
+author        = "SnapDisco Pty Ltd, Australia."
+description   = "Auto-generate a Python module that wraps a Nim module."
+license       = "MIT"
+
+[Deps]
+Requires: "nimrod >= 0.12.0"


### PR DESCRIPTION
This adds a `.nimble` file so that one can `nimble install .` and then import the `pymod` library from other modules. It's probably worth also putting Pymod in the Nimble index to coincide with this.

(@jboy note that I just took a stab at description and authorship – of course please feel free to change)